### PR TITLE
fix: bitbucket build status key dependent on the build name

### DIFF
--- a/src/lambda/shared/commitStatus.ts
+++ b/src/lambda/shared/commitStatus.ts
@@ -1,4 +1,5 @@
 import {bitbucketApiCall, githubApiCall} from './api';
+import {createHash} from 'crypto';
 
 export const sendCommitStatus = async (
     repositoryHost: string, repositoryName: string, token: string,
@@ -33,7 +34,8 @@ const sendBitbucketCommitStatus = async (
     status: string, commitSha: string, buildName: string, buildUrl: string, description: string,
 ) => {
     const response = await bitbucketApiCall(token, `repositories/${repositoryName}/commit/${commitSha}/statuses/build`, 'POST', {
-        key: 'AWS-PIPELINE-BUILD',
+    // hash function used, because build status key must be shorter than 40 characters
+        key: createHash('md5').update(buildName).digest('hex'),
         state: status,
         name: buildName,
         description: description,


### PR DESCRIPTION
In the current setup, build statuses sent to Bitbucket use a constant build status key - `AWS-PIPELINE-BUILD`. It works fine for poly-repo projects, but when you develop a monorepo with multiple AWS CDK apps, you can see only one build status in Bitbucket for all of the apps (the last build overwrites all the previous build statuses, because they reuse the same build status key).

To support monorepo, build status key must be dependent on the build name, however the build status key in Bitbucket can be maximally 40 characters long, what can be easily exceeded when you use longer branch names. That's why we use a hash function that produces a 32 character long string.

Here's the build status result taken from Bitbucket with the updated key:
<img width="312" alt="image" src="https://github.com/merapar/opinionated-ci-pipeline/assets/7798607/45cc065a-c8fa-41fa-9c32-d9eaeedb1634">
