### PR TITLE
fix: add prefix to the identifier of CI stack

### DIFF
--- a/src/cdkApplication.ts
+++ b/src/cdkApplication.ts
@@ -17,7 +17,7 @@ export class CDKApplication extends App {
 
         if (ci && ci.toLowerCase() === 'true') {
             const environment = getEnvironmentConfig(this, 'ci');
-            new CIStack(this, 'CI', {
+            new CIStack(this, `${projectName}CI`, {
                 stackName: `${projectName}-ci`,
                 env: environment,
                 ...props,


### PR DESCRIPTION
CDK Pipeline creates a KMS key used to encrypt objects in the default artifacts bucket together with a KMS key alias. The name of the alias is automatically generated based on the hierarchy of construct identifiers starting from stack id, e.g. `codepipeline-cimainpipeline${HASH}`. 

It's problematic when someone wants to deploy more than one Opinionated CI Pipeline in the same AWS account, because KMS key aliases will be the same.

This change adds the project name as a prefix in the CIStack identifier. This will make it possible to use multiple Opinionated CI Pipelines in the same AWS account, because KMS key aliases will include the prefix.