### PR TITLE
feat!: support separate Slack channels for main pipeline and feature deployments

### DIFF
--- a/src/applicationProps.ts
+++ b/src/applicationProps.ts
@@ -187,21 +187,22 @@ export interface CodePipelineOverrides {
     readonly enableKeyRotation?: boolean;
 }
 
-export interface SlackNotifications {
+export interface SlackChannelConfig {
     readonly workspaceId: string;
     readonly channelId: string;
+}
 
+export interface SlackNotifications {
     /**
-     * Whether to notify about main pipeline failures.
-     * @default true
+     * Slack notifications configuration for main pipeline failures.
+     * @default Slack notifications are not being sent
      */
-    readonly mainPipelineFailures?: boolean;
-
+    readonly mainPipelineFailures?: SlackChannelConfig;
     /**
-     * Whether to notify about feature branch deployment failures.
-     * @default false
+     * Slack notifications configuration for feature branch deployment failures.
+     * @default Slack notifications are not being sent
      */
-    readonly featureBranchFailures?: boolean;
+    readonly featureBranchFailures?: SlackChannelConfig;
 }
 
 export const defaultProps = {
@@ -220,9 +221,6 @@ export const defaultProps = {
             computeType: ComputeType.MEDIUM,
             buildImage: LinuxBuildImage.STANDARD_7_0,
         },
-    },
-    slackNotifications: {
-        mainPipelineFailures: true,
     },
 }; // "satisfies PartialDeep<CIStackProps>" would be great here if jsii supported TypeScript 4.9 (PartialDeep from type-fest lib)
 

--- a/src/constructs/mainPipeline.ts
+++ b/src/constructs/mainPipeline.ts
@@ -1,7 +1,13 @@
 import {Repository} from 'aws-cdk-lib/aws-codecommit';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import {Construct} from 'constructs';
-import {ApplicationProps, EnvironmentDeployment, IStacksCreation, ResolvedApplicationProps, WaveDeployment} from '../applicationProps';
+import {
+    ApplicationProps,
+    EnvironmentDeployment,
+    IStacksCreation,
+    ResolvedApplicationProps,
+    WaveDeployment,
+} from '../applicationProps';
 import {CustomNodejsFunction} from './customNodejsFunction';
 import * as path from 'path';
 import {NotificationsTopic} from './notificationsTopic';
@@ -15,6 +21,7 @@ import {Code} from 'aws-cdk-lib/aws-lambda';
 import {Topic} from 'aws-cdk-lib/aws-sns';
 import {IStringParameter} from 'aws-cdk-lib/aws-ssm';
 import {PipelineNotificationEvents} from 'aws-cdk-lib/aws-codepipeline';
+import {capitalizeFirstLetter} from '../util/string';
 
 export interface MainPipelineProps extends Pick<ResolvedApplicationProps,
     'stacks' | 'repository' | 'commands' |
@@ -178,4 +185,3 @@ export class MainPipeline extends Construct {
     }
 }
 
-const capitalizeFirstLetter = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,0 +1,1 @@
+export const capitalizeFirstLetter = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,2 +1,0 @@
-export const notEmpty = <TValue>(value: TValue | null | undefined): value is TValue =>
-    value !== null && value !== undefined;


### PR DESCRIPTION
Currently Opinionated CI Pipeline supports creating only a single Slack channel for notifications related to failures of the main pipeline and feature deployments. Sometimes it's easy to overlook main pipeline failure between feature deployments' failures, however failure of the main pipeline is much more important and needs to be addressed swiftly.

In this PR we've introduced separate Slack channel configuration for main pipeline failures and for feature deployment failures.

