### PR TITLE
fix: separate repo mirror zips per branch

### DIFF
--- a/src/constructs/mainPipeline.ts
+++ b/src/constructs/mainPipeline.ts
@@ -36,7 +36,7 @@ export class MainPipeline extends Construct {
     constructor(scope: Construct, id: string, props: MainPipelineProps) {
         super(scope, id);
 
-        const source = CodePipelineSource.s3(props.sourceBucket, 'repository-mirror.zip', {
+        const source = CodePipelineSource.s3(props.sourceBucket, `repository-${props.repository.defaultBranch}.zip`, {
             trigger: S3Trigger.NONE,
         });
 


### PR DESCRIPTION
When pipeline was changed and re-started,
it took latest repository zip version.
This could be a commit not from the default branch. In effect, the main pipeline could deploy a branch version.

Now, every branch is mirrored to a separate zip.
It prevents such collisions and also makes easier to manually start main pipeline or branch builds by providing file name, not exact object version.